### PR TITLE
renamed uninstall constant name

### DIFF
--- a/admin-page-framework-loader.php
+++ b/admin-page-framework-loader.php
@@ -209,7 +209,7 @@ AdminPageFrameworkLoader_Registry::setUp( __FILE__ );
 
 // Initial checks. - Do no load if accessed directly, not exiting because the 'uninstall.php' or inclusion list generator will load this file.
 if ( ! defined( 'ABSPATH' ) ) { return; }
-if ( defined( 'DOWING_UNINSTALL' ) ) { return; }
+if ( defined( 'DOING_UNINSTALL' ) ) { return; }
 
 // Include the library file 
 if ( ! class_exists( 'AdminPageFramework' ) ) {    

--- a/uninstall.php
+++ b/uninstall.php
@@ -21,8 +21,8 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
  * We are going to load the main file to get the registry class. And in the main file, 
  * if this constant is set, it will return after declaring the registry class.
  **/
-if ( ! defined( 'DOWING_UNINSTALL' ) ) {
-    define( 'DOWING_UNINSTALL', true  );
+if ( ! defined( 'DOING_UNINSTALL' ) ) {
+    define( 'DOING_UNINSTALL', true  );
 }
 
 /**


### PR DESCRIPTION
The constant for checking if uninstall is occurring is misnamed (extra W in the name). Renamed for clarity.