### PR TITLE
Add "wordpress-plugin" type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "keywords": ["WordPress", "framework", "admin page", "form", "settings", "options", "plugin"],
     "homepage": "http://admin-page-framework.michaeluno.jp/",
     "license": "GPL-2.0+",
+    "type": "wordpress-plugin",
     "require": {
         "php": ">=5.2.4"
     }

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,8 @@
     "type": "wordpress-plugin",
     "require": {
         "php": ">=5.2.4"
+    },
+    "suggest": {
+        "composer/installers": "~1.0"
     }
 }


### PR DESCRIPTION
Since this is a WordPress plugin, it's helpful to have the Composer type set to `wordpress-plugin`.  In many setups (such as [Bedrock](https://roots.io/bedrock/)) this will automatically instruct Composer to install the package in the site's `plugins` directory.