### PR TITLE
Found some variable-name typos

### DIFF
--- a/development/factory/_common/utility/AdminPageFramework_ArrayHandler.php
+++ b/development/factory/_common/utility/AdminPageFramework_ArrayHandler.php
@@ -187,7 +187,7 @@ class AdminPageFramework_ArrayHandler extends AdminPageFramework_FrameworkUtilit
             return;
         }
 
-        $this->unsetDimensionalArrayElement( $this->aData, $aKeys );
+        $this->unsetDimensionalArrayElement( $this->aData, $_asKeys );
 
     }
 

--- a/development/factory/_common/utility/AdminPageFramework_ErrorReporting.php
+++ b/development/factory/_common/utility/AdminPageFramework_ErrorReporting.php
@@ -39,7 +39,7 @@ class AdminPageFramework_ErrorReporting {
 
     public function __construct( $iLevel=null ) {
         $this->_iLevel = null !== $iLevel
-            ? $iLeevl
+            ? $iLevel
             : error_reporting();
     }
 

--- a/development/factory/_common/utility/wp_utility/AdminPageFramework_WPUtility_Meta.php
+++ b/development/factory/_common/utility/wp_utility/AdminPageFramework_WPUtility_Meta.php
@@ -38,7 +38,7 @@ class AdminPageFramework_WPUtility_Meta extends AdminPageFramework_WPUtility_Opt
      * @since       3.8.0
      */
     static public function getSavedTermMetaArray( $iTermID, array $aKeys ) {
-        return self::getMetaDataByKeys( $iUserID, $aKeys, 'term' );
+        return self::getMetaDataByKeys( $iTermID, $aKeys, 'term' );
     }
 
     /**

--- a/development/factory/admin_page/_controller/AdminPageFramework_Link_admin_page.php
+++ b/development/factory/admin_page/_controller/AdminPageFramework_Link_admin_page.php
@@ -304,7 +304,7 @@ class AdminPageFramework_Link_admin_page extends AdminPageFramework_Link_Base {
         foreach( array_filter( $this->oProp->aPluginTitleLinks ) as $_sLinkHTML ) {
 
             if ( is_array( $_sLinkHTML ) ) {
-                $_aAddingLinks = array_merge( $_sLinkHTML, $aAddingLinks );
+                $_aAddingLinks = array_merge( $_sLinkHTML, $_aAddingLinks );
                 continue;
             } 
             $_aAddingLinks[] = ( string ) $_sLinkHTML;

--- a/development/factory/page_meta_box/AdminPageFramework_PageMetaBox_Controller.php
+++ b/development/factory/page_meta_box/AdminPageFramework_PageMetaBox_Controller.php
@@ -49,7 +49,7 @@ abstract class AdminPageFramework_PageMetaBox_Controller extends AdminPageFramew
      */
     public function enqueueScripts( $aSRCs, $sPageSlug='', $sTabSlug='', $aCustomArgs=array() ) {
         if ( method_exists( $this->oResource, '_enqueueScripts' ) ) {
-            return $this->oResource->_enqueueScripts( $sSRC, $sPageSlug, $sTabSlug, $aCustomArgs );
+            return $this->oResource->_enqueueScripts( $aSRCs, $sPageSlug, $sTabSlug, $aCustomArgs );
         }
     }
     /**

--- a/library/apf/factory/_common/utility/AdminPageFramework_ArrayHandler.php
+++ b/library/apf/factory/_common/utility/AdminPageFramework_ArrayHandler.php
@@ -79,7 +79,7 @@ class AdminPageFramework_FrameworkUtility extends AdminPageFramework_WPUtility {
                 $this->aData[$_asKeys] = $_mValue;
                 return;
             }
-            $this->unsetDimensionalArrayElement($this->aData, $aKeys);
+            $this->unsetDimensionalArrayElement($this->aData, $_asKeys);
         }
         public function __toString() {
             return $this->getObjectInfo($this);

--- a/library/apf/factory/_common/utility/AdminPageFramework_ErrorReporting.php
+++ b/library/apf/factory/_common/utility/AdminPageFramework_ErrorReporting.php
@@ -8,7 +8,7 @@ class AdminPageFramework_ErrorReporting {
     private $_aLevels = array(1 => 'E_ERROR', 2 => 'E_WARNING', 4 => 'E_PARSE', 8 => 'E_NOTICE', 16 => 'E_CORE_ERROR', 32 => 'E_CORE_WARNING', 64 => 'E_COMPILE_ERROR', 128 => 'E_COMPILE_WARNING', 256 => 'E_USER_ERROR', 512 => 'E_USER_WARNING', 1024 => 'E_USER_NOTICE', 2048 => 'E_STRICT', 4096 => 'E_RECOVERABLE_ERROR', 8192 => 'E_DEPRECATED', 16384 => 'E_USER_DEPRECATED');
     private $_iLevel;
     public function __construct($iLevel = null) {
-        $this->_iLevel = null !== $iLevel ? $iLeevl : error_reporting();
+        $this->_iLevel = null !== $iLevel ? $iLevel : error_reporting();
     }
     public function getErrorLevel() {
         return $this->_getErrorDescription($this->_getIncluded());

--- a/library/apf/factory/_common/utility/wp_utility/AdminPageFramework_WPUtility.php
+++ b/library/apf/factory/_common/utility/wp_utility/AdminPageFramework_WPUtility.php
@@ -504,7 +504,7 @@ class AdminPageFramework_WPUtility_URL extends AdminPageFramework_Utility {
             return self::getMetaDataByKeys($iUserID, $aKeys, 'user');
         }
         static public function getSavedTermMetaArray($iTermID, array $aKeys) {
-            return self::getMetaDataByKeys($iUserID, $aKeys, 'term');
+            return self::getMetaDataByKeys($iTermID, $aKeys, 'term');
         }
         static public function getMetaDataByKeys($iObjectID, $aKeys, $sMetaType = 'post') {
             $_aSavedMeta = array();

--- a/library/apf/factory/admin_page/_controller/AdminPageFramework_Link_admin_page.php
+++ b/library/apf/factory/admin_page/_controller/AdminPageFramework_Link_admin_page.php
@@ -93,7 +93,7 @@ class AdminPageFramework_Link_admin_page extends AdminPageFramework_Link_Base {
         $_aAddingLinks = array();
         foreach (array_filter($this->oProp->aPluginTitleLinks) as $_sLinkHTML) {
             if (is_array($_sLinkHTML)) {
-                $_aAddingLinks = array_merge($_sLinkHTML, $aAddingLinks);
+                $_aAddingLinks = array_merge($_sLinkHTML, $_aAddingLinks);
                 continue;
             }
             $_aAddingLinks[] = ( string )$_sLinkHTML;

--- a/library/apf/factory/page_meta_box/AdminPageFramework_PageMetaBox.php
+++ b/library/apf/factory/page_meta_box/AdminPageFramework_PageMetaBox.php
@@ -131,7 +131,7 @@ abstract class AdminPageFramework_PageMetaBox_Router extends AdminPageFramework_
         }
         public function enqueueScripts($aSRCs, $sPageSlug = '', $sTabSlug = '', $aCustomArgs = array()) {
             if (method_exists($this->oResource, '_enqueueScripts')) {
-                return $this->oResource->_enqueueScripts($sSRC, $sPageSlug, $sTabSlug, $aCustomArgs);
+                return $this->oResource->_enqueueScripts($aSRCs, $sPageSlug, $sTabSlug, $aCustomArgs);
             }
         }
         public function enqueueScript($sSRC, $sPageSlug = '', $sTabSlug = '', $aCustomArgs = array()) {


### PR DESCRIPTION
While doing final inspection for a plugin I'm rolling out, I found and corrected a few (apparent) typos in variable names in framework code.

Actually I should credit my JetBrains IDE for most of this.

Here are my corrections.