### PR TITLE
#301 Fix some deprecation notices.

### DIFF
--- a/development/factory/_common/_abstract/_model/AdminPageFramework_Property_Base.php
+++ b/development/factory/_common/_abstract/_model/AdminPageFramework_Property_Base.php
@@ -459,7 +459,7 @@ abstract class AdminPageFramework_Property_Base extends AdminPageFramework_Frame
                 self::$___sCacheReferrer = isset( self::$___sCacheReferrer )
                     ? self::$___sCacheReferrer
                     : wp_get_referer();
-                return self::$___sCacheReferrer;
+                return is_string( self::$___sCacheReferrer ) ? self::$___sCacheReferrer : '';
             }
             /**
              *

--- a/development/factory/_common/_abstract/_view/AdminPageFramework_TabNavigationBar.php
+++ b/development/factory/_common/_abstract/_view/AdminPageFramework_TabNavigationBar.php
@@ -26,6 +26,10 @@ class AdminPageFramework_TabNavigationBar extends AdminPageFramework_FrameworkUt
      * Stores the tab items.
      */
     public $aTabs   = array();
+    /**
+     * Stores the active slugs.
+     */
+    public $aActiveSlugs   = array();
 
     /**
      * Stores container attributes.

--- a/development/factory/_common/form/AdminPageFramework_Form.php
+++ b/development/factory/_common/form/AdminPageFramework_Form.php
@@ -45,6 +45,11 @@ class AdminPageFramework_Form extends AdminPageFramework_Form_Controller {
     );
 
     /**
+     * Stores sections definitions.
+     */
+    public $aSections  = array();
+
+    /**
      * Stores field set definitions.
      */
     public $aFieldsets    = array();

--- a/development/factory/_common/form/_view/sectionset/AdminPageFramework_Form_View___FieldTitle.php
+++ b/development/factory/_common/form/_view/sectionset/AdminPageFramework_Form_View___FieldTitle.php
@@ -90,7 +90,7 @@ class AdminPageFramework_Form_View___FieldTitle extends AdminPageFramework_Form_
                                 strip_tags(
                                     is_array( $aField[ 'description' ] )
                                         ? implode( '&#10;', $aField[ 'description' ] )
-                                        : $aField[ 'description' ]
+                                        : ( is_string( $aField[ 'description' ] ) ? $aField[ 'description' ] : '' )
                                 )
                             )
                         . "'>"

--- a/development/factory/_common/utility/base_utility/AdminPageFramework_Utility_HTMLAttribute.php
+++ b/development/factory/_common/utility/base_utility/AdminPageFramework_Utility_HTMLAttribute.php
@@ -115,9 +115,9 @@ abstract class AdminPageFramework_Utility_HTMLAttribute extends AdminPageFramewo
             }
 
             // At this point, it is a string. Break them down to array elements.
-            $__aCSSRules = explode( ';', $_asCSSRules );
+            $__aCSSRules = explode( ';', is_string( $_asCSSRules ) ? $_asCSSRules : '' );
             foreach( $__aCSSRules as $_sPair ) {
-                $_aCSSPair = explode( ':', $_sPair );
+                $_aCSSPair = explode( ':', ( is_string( $_sPair )? $_sPair : '' ) );
                 if ( ! isset( $_aCSSPair[ 0 ], $_aCSSPair[ 1 ] ) ) {
                     continue;
                 }

--- a/development/factory/admin_page/_model/delegate/validaor/AdminPageFramework_Model__FormSubmission__Validator__Reset.php
+++ b/development/factory/admin_page/_model/delegate/validaor/AdminPageFramework_Model__FormSubmission__Validator__Reset.php
@@ -43,10 +43,10 @@ class AdminPageFramework_Model__FormSubmission__Validator__Reset extends AdminPa
             $aSubmits,
             'reset_key'
         );
-        $_sKeyToReset = trim( $_sKeyToReset );
         if ( ! $_sKeyToReset ) {
             return;
         }
+        $_sKeyToReset = trim( $_sKeyToReset );
         $_oException = new Exception( 'aReturn' );
         $_oException->aReturn = $this->_resetOptions(
             $_sKeyToReset,

--- a/development/utility/toc/AdminPageFramework_TableOfContents.php
+++ b/development/utility/toc/AdminPageFramework_TableOfContents.php
@@ -86,6 +86,7 @@ class AdminPageFramework_TableOfContents {
 
         $_aOutput = array();
         foreach( $this->_aMatches as $_iIndex => $_sMatch ) {
+            $_sMatch = is_string( $_sMatch ) ? $_sMatch : '';
             $_sMatch = strip_tags( $_sMatch, '<h1><h2><h3><h4><h5><h6><h7><h8>' );
             $_sMatch = preg_replace( '/<h([1-' . $iDepth . '])>/', '<li class="toc$1"><a href="#toc_' . $_iIndex . '">', $_sMatch );
             $_sMatch = preg_replace( '/<\/h[1-' . $iDepth . ']>/', '</a></li>', $_sMatch );

--- a/library/apf/factory/_common/_abstract/_view/AdminPageFramework_TabNavigationBar.php
+++ b/library/apf/factory/_common/_abstract/_view/AdminPageFramework_TabNavigationBar.php
@@ -9,6 +9,7 @@
 class AdminPageFramework_TabNavigationBar extends AdminPageFramework_FrameworkUtility {
     public $sTabTag = 'h2';
     public $aTabs = array();
+    public $aActiveSlugs;
     public $aAttributes = array( 'class' => 'nav-tab-wrapper', );
     public $aTab = array( 'slug' => null, 'title' => null, 'href' => null, 'disabled' => null, 'class' => null, 'attributes' => array(), );
     public $aCallbacks = array( 'format' => null, 'arguments' => array(), );

--- a/library/apf/factory/_common/form/AdminPageFramework_Form.php
+++ b/library/apf/factory/_common/form/AdminPageFramework_Form.php
@@ -10,6 +10,7 @@ class AdminPageFramework_Form extends AdminPageFramework_Form_Controller {
     public $sStructureType = '';
     public $aFieldTypeDefinitions = array();
     public $aSectionsets = array( '_default' => array( 'section_id' => '_default', ), );
+    public $aSections = array();
     public $aFieldsets = array();
     public $aSavedData = array();
     public $sCapability = '';

--- a/library/apf/factory/_common/utility/base_utility/AdminPageFramework_Utility_HTMLAttribute.php
+++ b/library/apf/factory/_common/utility/base_utility/AdminPageFramework_Utility_HTMLAttribute.php
@@ -42,7 +42,7 @@ abstract class AdminPageFramework_Utility_HTMLAttribute extends AdminPageFramewo
                 $_aCSSRules = array_merge($_asCSSRules, $_aCSSRules);
                 continue;
             }
-            $__aCSSRules = explode(';', $_asCSSRules);
+            $__aCSSRules = explode( ';', is_string( $_asCSSRules ) ? $_asCSSRules : '' );
             foreach ($__aCSSRules as $_sPair) {
                 $_aCSSPair = explode(':', $_sPair);
                 if (! isset($_aCSSPair[ 0 ], $_aCSSPair[ 1 ])) {

--- a/library/apf/factory/admin_page/_model/delegate/validaor/AdminPageFramework_Model__FormSubmission__Validator__Reset.php
+++ b/library/apf/factory/admin_page/_model/delegate/validaor/AdminPageFramework_Model__FormSubmission__Validator__Reset.php
@@ -16,10 +16,10 @@ class AdminPageFramework_Model__FormSubmission__Validator__Reset extends AdminPa
             return;
         }
         $_sKeyToReset = $this->_getPressedSubmitButtonData($aSubmits, 'reset_key');
-        $_sKeyToReset = trim($_sKeyToReset);
         if (! $_sKeyToReset) {
             return;
         }
+        $_sKeyToReset = trim($_sKeyToReset);
         $_oException = new Exception('aReturn');
         $_oException->aReturn = $this->_resetOptions($_sKeyToReset, $aInputs, $aSubmitInformation);
         throw $_oException;


### PR DESCRIPTION
Substitute empty strings for null values in some calls to explode() and strip_tags(). Declare some class properties to eliminate dynamic property declarations.

This work is done in two places: /development/ and /library/. I don't understand your build workflow, so I just modified both copies of the software.